### PR TITLE
Added ssm-permissions.json to policies folder

### DIFF
--- a/policies/ssm-permisions.json
+++ b/policies/ssm-permisions.json
@@ -1,0 +1,23 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "ssm:PutParameter",
+                "ssm:LabelParameterVersion",
+                "ssm:DeleteParameter",
+                "ssm:UnlabelParameterVersion",
+                "ssm:DescribeParameters",
+                "ssm:GetParameterHistory",
+                "ssm:ListTagsForResource",
+                "ssm:GetParametersByPath",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:DeleteParameters"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
This policy is needed for someone trying to follow the tutorial. It also fixes the issue -"ssm:ListTagsForResource" needed for the ssm resource policy .